### PR TITLE
Update TCP port to fit WeMo_WW_2.00.10966 firmware

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@ WeMo-PHP-Toolkit
 
 * Author: Thorne Melcher (GitHub: ExistentialEnso)
 * License: LGPL v3 (more permissive commercial licensing available for a fee on request)
-* Version: 0.1.1
 
 PHP classes for use with Belkin's WeMo system. Currently only has an "Outlet" class (sorry, that's the only WeMo product
 I own!)
@@ -32,6 +31,7 @@ $ composer.phar install
 
 ```php
 $outlet = new Outlet("192.168.1.x"); // Change to location of Outlet on your network
+$outlet = new Outlet("192.168.1.x","49513"); // Optional you can add the port where the device is reachable
 $outlet->setIsOn(false); // Outlet will shut off!
 ```
 
@@ -43,3 +43,13 @@ $outlet->getDisplayName(); // e.g. "Air Purifier"
 $outlet->getManufacturer(); // e.g. "Belkin"
 $outlet->getModelDescription(); // e.g. "Belkin Plugin Socket 1.0"
 ```
+
+
+# Version History
+
+*Version: 0.2.1 (2017-09-26)*
+  - Optional port can be configured
+  - If not port is configured automatic search of applicable device port (49152, 49153, 49154)
+  - Add method refresh on object construct to fill device information properties
+
+*Version: 0.1.1*

--- a/src/Wemo/Models/Device.php
+++ b/src/Wemo/Models/Device.php
@@ -27,7 +27,7 @@ abstract class Device {
    *
    * @var int
    */
-  protected $port = 49153;
+  protected $port = 49154;
 
   /**
    * The MAC address of the device.

--- a/src/Wemo/Models/Outlet.php
+++ b/src/Wemo/Models/Outlet.php
@@ -31,6 +31,16 @@ class Outlet extends Device {
   public function __construct($ip_address, $port = null) {
     $this->ip_address = $ip_address;
     if ( $port ) $this->port = $port;
+    $this->refresh();
+  }
+
+  /**
+   * Enable to change the IP and port of exsiting object
+   */
+  public function setIP($ip_address, $port = null) {
+    $this->ip_address = $ip_address;
+    if ( $port ) $this->port = $port;
+    $this->refresh();
   }
 
   /**
@@ -41,8 +51,20 @@ class Outlet extends Device {
     $contents = @file_get_contents("http://" . $this->ip_address . ":" . $this->port . "/setup.xml");
 
     if($contents === false) {
+
+      if ($this->port == "49154") {
+        $this->port = "49153";
+        $this->refresh();
+        return;
+      }
+      elseif ( $this->port == "49153") {
+        $this->port = "49152";
+        $this->refresh();
+        return;
+      }
+
       $this->properties_fetched;
-      trigger_error("Unable to connect to outlet at " . $ip_address, E_USER_WARNING);
+      trigger_error("Unable to connect to outlet at " . $this->ip_address, E_USER_WARNING);
     }
 
     $contents = new \SimpleXMLElement($contents);

--- a/src/Wemo/Models/Outlet.php
+++ b/src/Wemo/Models/Outlet.php
@@ -35,15 +35,6 @@ class Outlet extends Device {
   }
 
   /**
-   * Enable to change the IP and port of exsiting object
-   */
-  public function setIP($ip_address, $port = null) {
-    $this->ip_address = $ip_address;
-    if ( $port ) $this->port = $port;
-    $this->refresh();
-  }
-
-  /**
    * Updates the Outlet's state by pulling info from the outlet itself.
    */
   public function refresh() {

--- a/src/Wemo/Models/Outlet.php
+++ b/src/Wemo/Models/Outlet.php
@@ -28,8 +28,9 @@ class Outlet extends Device {
    *
    * @param $ip_address
    */
-  public function __construct($ip_address) {
+  public function __construct($ip_address, $port = null) {
     $this->ip_address = $ip_address;
+    if ( $port ) $this->port = $port;
   }
 
   /**


### PR DESCRIPTION
The WEMO firmware version WeMo_WW_2.00.10966.PVT-OWRT-SN seems to use different ports as the previous versions. The modification has been tested with (http://192.168.1.xx:xx/setup.xml) using a Insight Switch (Model F5Z0340ea) and WEMO Motion Sensor (Both are European Version).

CHANGES
NEW: TCP Port can be optional configured on object construct
NEW: Add function to test current used port options: 49152, 49153, 49154
CORRECTION: Add method refresh on object construct to fill device information properties